### PR TITLE
Add onPurge callback

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,5 @@
+{
+    "singleQuote": true,
+    "bracketSpacing": false,
+    "trailingComma": "es5"
+}

--- a/README.md
+++ b/README.md
@@ -194,6 +194,7 @@ You can see an example of this method in action [here](https://codepen.io/rsreus
 | `revision` | `Number` | `undefined` | When provided, causes the plot to update *only* when the revision is incremented. |
 | `debug` | `Boolean` | `false` | Assign the graph div to `window.gd` for debugging |
 | `onInitialized` | `Function` | `undefined` | Callback executed after plot is initialized |
+| `onPurge` | `Function` | `undefined` | Callback executed when component unmounts. Unmounting triggers a Plotly.purge event which strips the graphDiv of all plotly.js related information including data and layout. This hook gives application writers a chance to pull data and layout off the DOM. |
 | `onUpdate` | `Function` | `undefined` | Callback executed when a plotly.js API method resolves |
 | `onError` | `Function` | `undefined` | Callback executed when a plotly.js API method rejects |
 

--- a/example/src/components/code.js
+++ b/example/src/components/code.js
@@ -1,10 +1,10 @@
-import React, { Component } from "react";
-import CodeMirror from "react-codemirror2";
-require("../../../node_modules/codemirror/mode/javascript/javascript");
+import React, {Component} from 'react';
+import CodeMirror from 'react-codemirror2';
+require('../../../node_modules/codemirror/mode/javascript/javascript');
 
-import styles from "./code.css";
+import styles from './code.css';
 
-require("insert-css")(`
+require('insert-css')(`
 .ReactCodeMirror,
 .CodeMirror {
     height: 100%;
@@ -14,16 +14,16 @@ require("insert-css")(`
 export default class Code extends Component {
   render() {
     const classes = [styles.codeContainer];
-    if (!this.props.valid) classes.push(styles["codeContainer--invalid"]);
+    if (!this.props.valid) classes.push(styles['codeContainer--invalid']);
 
     return (
-      <div className={classes.join(" ")}>
+      <div className={classes.join(' ')}>
         <CodeMirror
           value={this.props.value}
           onValueChange={this.props.onChange}
           options={{
             mode: {
-              name: "javascript",
+              name: 'javascript',
               json: true,
             },
           }}

--- a/example/src/components/plot.js
+++ b/example/src/components/plot.js
@@ -1,7 +1,7 @@
-import React from "react";
-import styles from "./plot.css";
+import React from 'react';
+import styles from './plot.css';
 
-import PlotComponent from "../../../src/react-plotly.js";
+import PlotComponent from '../../../src/react-plotly.js';
 
 export default class Plot extends React.Component {
   shouldComponentUpdate(nextProps) {
@@ -17,9 +17,9 @@ export default class Plot extends React.Component {
           config={this.props.data.config}
           frames={this.props.data.frames}
           fit={this.props.fit}
-          onClick={e => console.log("plotly_click:", e)}
-          onHover={e => console.log("plotly_hover:", e)}
-          onUnhover={e => console.log("plotly_unhover:", e)}
+          onClick={e => console.log('plotly_click:', e)}
+          onHover={e => console.log('plotly_hover:', e)}
+          onUnhover={e => console.log('plotly_unhover:', e)}
           debug
         />
       </div>

--- a/example/src/index.js
+++ b/example/src/index.js
@@ -1,20 +1,20 @@
-import React from "react";
-import ReactDOM from "react-dom";
-import Plot from "./components/plot";
-import Code from "./components/code";
-var fs = require("fs");
-import path from "path";
-import styles from "./index.css";
-import Dat, { DatNumber, DatBoolean } from "react-dat-gui";
-import DatSelect from "./components/DatSelect.jsx";
-import beautify from "json-beautify";
+import React from 'react';
+import ReactDOM from 'react-dom';
+import Plot from './components/plot';
+import Code from './components/code';
+var fs = require('fs');
+import path from 'path';
+import styles from './index.css';
+import Dat, {DatNumber, DatBoolean} from 'react-dat-gui';
+import DatSelect from './components/DatSelect.jsx';
+import beautify from 'json-beautify';
 
-const initialData = fs.readFileSync(__dirname + "/example.json", "utf8");
+const initialData = fs.readFileSync(__dirname + '/example.json', 'utf8');
 
 class App extends React.Component {
   state = {
     value: initialData,
-    data: "",
+    data: '',
     valid: true,
     config: {
       width: 0,
@@ -28,11 +28,11 @@ class App extends React.Component {
     this.handleCode(null, null, initialData);
 
     fetch(
-      "https://api.github.com/repositories/45646037/contents/test/image/mocks"
+      'https://api.github.com/repositories/45646037/contents/test/image/mocks'
     ).then(data => {
       data.json().then(mocks => {
         this.setState({
-          mocks: [{ label: "- Select -", value: "" }].concat(
+          mocks: [{label: '- Select -', value: ''}].concat(
             mocks.map(m => ({
               label: m.name,
               value: m.download_url,
@@ -54,7 +54,7 @@ class App extends React.Component {
         data: parsed,
       });
     } catch (e) {
-      this.setState({ valid: false });
+      this.setState({valid: false});
     }
   };
 
@@ -107,7 +107,7 @@ class App extends React.Component {
           <Dat
             data={this.state.config}
             onUpdate={this.handleConfig}
-            style={{ zIndex: 100, marginTop: "1px" }}
+            style={{zIndex: 100, marginTop: '1px'}}
           >
             <DatBoolean path="fit" label="Fit" />
             <DatNumber path="width" min={0} max={1024} step={1} label="Width" />
@@ -131,6 +131,6 @@ class App extends React.Component {
   }
 }
 
-const root = document.createElement("div");
+const root = document.createElement('div');
 document.body.appendChild(root);
 ReactDOM.render(<App />, root);

--- a/src/__mocks__/plotly.js
+++ b/src/__mocks__/plotly.js
@@ -1,4 +1,4 @@
-import EventEmitter from "event-emitter";
+import EventEmitter from 'event-emitter';
 const state = {};
 
 const ASYNC_DELAY = 1;
@@ -7,7 +7,7 @@ export default {
   plot: jest.fn(gd => {
     state.gd = gd;
     setTimeout(() => {
-      state.gd.emit("plotly_afterplot");
+      state.gd.emit('plotly_afterplot');
     }, ASYNC_DELAY);
   }),
   newPlot: jest.fn(gd => {
@@ -15,19 +15,19 @@ export default {
     EventEmitter(state.gd);
 
     setTimeout(() => {
-      state.gd.emit("plotly_afterplot");
+      state.gd.emit('plotly_afterplot');
     }, ASYNC_DELAY);
   }),
   relayout: jest.fn(gd => {
     state.gd = gd;
     setTimeout(() => {
-      state.gd.emit("plotly_relayout");
+      state.gd.emit('plotly_relayout');
     }, ASYNC_DELAY);
   }),
   restyle: jest.fn(gd => {
     state.gd = gd;
     setTimeout(() => {
-      state.gd.emit("plotly_restyle");
+      state.gd.emit('plotly_restyle');
     }, ASYNC_DELAY);
   }),
   update: jest.fn(),

--- a/src/__tests__/react-plotly.test.js
+++ b/src/__tests__/react-plotly.test.js
@@ -1,9 +1,9 @@
-import React from "react";
-import { mount } from "enzyme";
-import createComponent from "../factory";
-import once from "onetime";
+import React from 'react';
+import {mount} from 'enzyme';
+import createComponent from '../factory';
+import once from 'onetime';
 
-describe("<Plotly/>", () => {
+describe('<Plotly/>', () => {
   let Plotly, PlotComponent;
 
   function createPlot(props) {
@@ -33,9 +33,9 @@ describe("<Plotly/>", () => {
     );
   }
 
-  describe("with mocked plotly.js", () => {
+  describe('with mocked plotly.js', () => {
     beforeEach(() => {
-      Plotly = require.requireMock("../__mocks__/plotly.js").default;
+      Plotly = require.requireMock('../__mocks__/plotly.js').default;
       PlotComponent = createComponent(Plotly);
 
       // Override the parent element size:
@@ -45,8 +45,8 @@ describe("<Plotly/>", () => {
       });
     });
 
-    describe("initialization", function() {
-      test("calls Plotly.newPlot on instantiation", done => {
+    describe('initialization', function() {
+      test('calls Plotly.newPlot on instantiation', done => {
         createPlot({})
           .then(() => {
             expect(Plotly.newPlot).toHaveBeenCalled();
@@ -57,42 +57,42 @@ describe("<Plotly/>", () => {
           .then(done);
       });
 
-      test("passes data", done => {
+      test('passes data', done => {
         createPlot({
-          data: [{ x: [1, 2, 3] }],
-          layout: { title: "foo" },
+          data: [{x: [1, 2, 3]}],
+          layout: {title: 'foo'},
         })
           .then(() => {
             expectPlotlyAPICall(Plotly.newPlot, {
-              data: [{ x: [1, 2, 3] }],
-              layout: { title: "foo" },
+              data: [{x: [1, 2, 3]}],
+              layout: {title: 'foo'},
             });
           })
           .catch(err => done.fail(err))
           .then(done);
       });
 
-      test("accepts width and height", done => {
+      test('accepts width and height', done => {
         createPlot({
-          layout: { width: 320, height: 240 },
+          layout: {width: 320, height: 240},
         })
           .then(() => {
             expectPlotlyAPICall(Plotly.newPlot, {
-              layout: { width: 320, height: 240 },
+              layout: {width: 320, height: 240},
             });
           })
           .catch(err => done.fail(err))
           .then(done);
       });
 
-      test("overrides the height when fit: true", done => {
+      test('overrides the height when fit: true', done => {
         createPlot({
-          layout: { width: 320, height: 240 },
+          layout: {width: 320, height: 240},
           fit: true,
         })
           .then(() => {
             expectPlotlyAPICall(Plotly.newPlot, {
-              layout: { width: 320, height: 240 },
+              layout: {width: 320, height: 240},
             });
           })
           .catch(err => done.fail(err))
@@ -100,42 +100,42 @@ describe("<Plotly/>", () => {
       });
     });
 
-    describe("plot updates", () => {
-      test("updates data", done => {
+    describe('plot updates', () => {
+      test('updates data', done => {
         createPlot({
           fit: true,
-          layout: { width: 123, height: 456 },
+          layout: {width: 123, height: 456},
           onUpdate: once(() => {
             expectPlotlyAPICall(Plotly.newPlot, {
-              data: [{ x: [1, 2, 3] }],
-              layout: { width: 123, height: 456 },
+              data: [{x: [1, 2, 3]}],
+              layout: {width: 123, height: 456},
             });
             done();
           }),
         })
           .then(plot => {
-            plot.setProps({ data: [{ x: [1, 2, 3] }] });
+            plot.setProps({data: [{x: [1, 2, 3]}]});
           })
           .catch(err => done.fail(err));
       });
 
-      test("sets the title", done => {
+      test('sets the title', done => {
         createPlot({
           fit: false,
           onUpdate: once(() => {
             expectPlotlyAPICall(Plotly.newPlot, {
-              layout: { title: "test test" },
+              layout: {title: 'test test'},
             });
             done();
           }),
         })
           .then(plot => {
-            plot.setProps({ layout: { title: "test test" } });
+            plot.setProps({layout: {title: 'test test'}});
           })
           .catch(err => done.fail(err));
       });
 
-      test("clear event handlers on newPlot", done => {
+      test('clear event handlers on newPlot', done => {
         let wrapper;
         createPlot({
           fit: false,
@@ -151,17 +151,17 @@ describe("<Plotly/>", () => {
             wrapper = plot;
 
             // make sure real clearLocalEventHandlers does the job
-            expect(Object.keys(wrapper.instance().handlers)).toEqual(["Click"]);
+            expect(Object.keys(wrapper.instance().handlers)).toEqual(['Click']);
             plot.instance().clearLocalEventHandlers();
             expect(Object.keys(wrapper.instance().handlers)).toEqual([]);
 
             plot.instance().clearLocalEventHandlers = jest.fn();
-            plot.setProps({ layout: { title: "test test" } });
+            plot.setProps({layout: {title: 'test test'}});
           })
           .catch(err => done.fail(err));
       });
 
-      test("revision counter", done => {
+      test('revision counter', done => {
         var callCnt = 0;
         createPlot({
           fit: false,
@@ -182,23 +182,17 @@ describe("<Plotly/>", () => {
         })
           .then(plot => {
             // Update with and without revision bumps:
+            setTimeout(() => plot.setProps({layout: {title: 'test test'}}), 10);
             setTimeout(
-              () => plot.setProps({ layout: { title: "test test" } }),
-              10
-            );
-            setTimeout(
-              () =>
-                plot.setProps({ revision: 1, layout: { title: "test test" } }),
+              () => plot.setProps({revision: 1, layout: {title: 'test test'}}),
               20
             );
             setTimeout(
-              () =>
-                plot.setProps({ revision: 1, layout: { title: "test test" } }),
+              () => plot.setProps({revision: 1, layout: {title: 'test test'}}),
               30
             );
             setTimeout(
-              () =>
-                plot.setProps({ revision: 2, layout: { title: "test test" } }),
+              () => plot.setProps({revision: 2, layout: {title: 'test test'}}),
               40
             );
           })
@@ -206,12 +200,12 @@ describe("<Plotly/>", () => {
       });
     });
 
-    describe("responding to window events", () => {
-      describe("with fit: true", () => {
-        test("does not call relayout on initialization", done => {
+    describe('responding to window events', () => {
+      describe('with fit: true', () => {
+        test('does not call relayout on initialization', done => {
           createPlot({
             fit: true,
-            onRelayout: () => done.fail("Unexpected relayout event"),
+            onRelayout: () => done.fail('Unexpected relayout event'),
           })
             .then(() => {
               setTimeout(done, 20);
@@ -219,7 +213,7 @@ describe("<Plotly/>", () => {
             .catch(err => done.fail(err));
         });
 
-        test("calls relayout on window resize when fit: true", done => {
+        test('calls relayout on window resize when fit: true', done => {
           let relayoutCnt = 0;
           createPlot({
             fit: true,
@@ -231,17 +225,17 @@ describe("<Plotly/>", () => {
             },
           })
             .then(() => {
-              window.dispatchEvent(new Event("resize"));
+              window.dispatchEvent(new Event('resize'));
             })
             .catch(err => done.fail(err));
         });
       });
 
-      describe("with fit: false", () => {
-        test("does not call relayout on init", done => {
+      describe('with fit: false', () => {
+        test('does not call relayout on init', done => {
           createPlot({
             fit: false,
-            onRelayout: () => done.fail("Unexpected relayout event"),
+            onRelayout: () => done.fail('Unexpected relayout event'),
           })
             .then(() => {
               setTimeout(done, 20);
@@ -249,13 +243,13 @@ describe("<Plotly/>", () => {
             .catch(err => done.fail(err));
         });
 
-        test("does not call relayout on window resize", done => {
+        test('does not call relayout on window resize', done => {
           createPlot({
             fit: false,
-            onRelayout: () => done.fail("Unexpected relayout event"),
+            onRelayout: () => done.fail('Unexpected relayout event'),
           })
             .then(() => {
-              window.dispatchEvent(new Event("resize"));
+              window.dispatchEvent(new Event('resize'));
               setTimeout(done, 20);
             })
             .catch(err => done.fail(err));

--- a/src/factory.js
+++ b/src/factory.js
@@ -1,51 +1,51 @@
-import React, { Component } from "react";
-import PropTypes from "prop-types";
-import isNumeric from "fast-isnumeric";
-import objectAssign from "object-assign";
+import React, {Component} from 'react';
+import PropTypes from 'prop-types';
+import isNumeric from 'fast-isnumeric';
+import objectAssign from 'object-assign';
 // import throttle from "throttle-debounce/throttle";
 
 // The naming convention is:
 //   - events are attached as `'plotly_' + eventName.toLowerCase()`
 //   - react props are `'on' + eventName`
 const eventNames = [
-  "AfterExport",
-  "AfterPlot",
-  "Animated",
-  "AnimatingFrame",
-  "AnimationInterrupted",
-  "AutoSize",
-  "BeforeExport",
-  "ButtonClicked",
-  "Click",
-  "ClickAnnotation",
-  "Deselect",
-  "DoubleClick",
-  "Framework",
-  "Hover",
-  "Relayout",
-  "Restyle",
-  "Redraw",
-  "Selected",
-  "Selecting",
-  "SliderChange",
-  "SliderEnd",
-  "SliderStart",
-  "Transitioning",
-  "TransitionInterrupted",
-  "Unhover",
+  'AfterExport',
+  'AfterPlot',
+  'Animated',
+  'AnimatingFrame',
+  'AnimationInterrupted',
+  'AutoSize',
+  'BeforeExport',
+  'ButtonClicked',
+  'Click',
+  'ClickAnnotation',
+  'Deselect',
+  'DoubleClick',
+  'Framework',
+  'Hover',
+  'Relayout',
+  'Restyle',
+  'Redraw',
+  'Selected',
+  'Selecting',
+  'SliderChange',
+  'SliderEnd',
+  'SliderStart',
+  'Transitioning',
+  'TransitionInterrupted',
+  'Unhover',
 ];
 
 const updateEvents = [
-  "plotly_restyle",
-  "plotly_redraw",
-  "plotly_relayout",
-  "plotly_doubleclick",
-  "plotly_animated",
+  'plotly_restyle',
+  'plotly_redraw',
+  'plotly_relayout',
+  'plotly_doubleclick',
+  'plotly_animated',
 ];
 
 // Check if a window is available since SSR (server-side rendering)
 // breaks unnecessarily if you try to use it server-side.
-const isBrowser = typeof window !== "undefined";
+const isBrowser = typeof window !== 'undefined';
 
 export default function plotComponentFactory(Plotly) {
   const hasReactAPIMethod = !!Plotly.react;
@@ -93,7 +93,7 @@ export default function plotComponentFactory(Plotly) {
           () => this.props.onInitialized && this.props.onInitialized(this.el)
         )
         .catch(e => {
-          console.error("Error while plotting:", e);
+          console.error('Error while plotting:', e);
           return this.props.onError && this.props.onError();
         });
     }
@@ -125,14 +125,14 @@ export default function plotComponentFactory(Plotly) {
         .then(this.attachUpdateEvents)
         .then(() => this.handleUpdate(nextProps))
         .catch(err => {
-          console.error("Error while plotting:", err);
+          console.error('Error while plotting:', err);
           this.props.onError && this.props.onError(err);
         });
     }
 
     componentWillUnmount() {
       if (this.resizeHandler && isBrowser) {
-        window.removeEventListener("resize", this.handleResize);
+        window.removeEventListener('resize', this.handleResize);
         this.resizeHandler = null;
       }
 
@@ -163,7 +163,7 @@ export default function plotComponentFactory(Plotly) {
 
     handleUpdate(props) {
       props = props || this.props;
-      if (props.onUpdate && typeof props.onUpdate === "function") {
+      if (props.onUpdate && typeof props.onUpdate === 'function') {
         props.onUpdate(this.el);
       }
     }
@@ -176,11 +176,11 @@ export default function plotComponentFactory(Plotly) {
         this.resizeHandler = () => {
           return Plotly.relayout(this.el, this.getSize());
         };
-        window.addEventListener("resize", this.resizeHandler);
+        window.addEventListener('resize', this.resizeHandler);
 
         if (invoke) return this.resizeHandler();
       } else if (!props.fit && this.resizeHandler) {
-        window.removeEventListener("resize", this.resizeHandler);
+        window.removeEventListener('resize', this.resizeHandler);
         this.resizeHandler = null;
       }
     }
@@ -200,16 +200,16 @@ export default function plotComponentFactory(Plotly) {
 
       for (let i = 0; i < eventNames.length; i++) {
         const eventName = eventNames[i];
-        const prop = props["on" + eventName];
+        const prop = props['on' + eventName];
         const hasHandler = !!this.handlers[eventName];
 
         if (prop && !hasHandler) {
-          let handler = (this.handlers[eventName] = props["on" + eventName]);
-          this.el.on("plotly_" + eventName.toLowerCase(), handler);
+          let handler = (this.handlers[eventName] = props['on' + eventName]);
+          this.el.on('plotly_' + eventName.toLowerCase(), handler);
         } else if (!prop && hasHandler) {
           // Needs to be removed:
           this.el.off(
-            "plotly_" + eventName.toLowerCase(),
+            'plotly_' + eventName.toLowerCase(),
             this.handlers[eventName]
           );
           delete this.handlers[eventName];
@@ -252,8 +252,8 @@ export default function plotComponentFactory(Plotly) {
       return (
         <div
           style={{
-            position: "relative",
-            display: "inline-block",
+            position: 'relative',
+            display: 'inline-block',
           }}
           ref={this.getRef}
         />
@@ -275,7 +275,7 @@ export default function plotComponentFactory(Plotly) {
   };
 
   for (let i = 0; i < eventNames.length; i++) {
-    PlotlyComponent.propTypes["on" + eventNames[i]] = PropTypes.func;
+    PlotlyComponent.propTypes['on' + eventNames[i]] = PropTypes.func;
   }
 
   PlotlyComponent.defaultProps = {

--- a/src/factory.js
+++ b/src/factory.js
@@ -131,6 +131,9 @@ export default function plotComponentFactory(Plotly) {
     }
 
     componentWillUnmount() {
+      if (this.props.onPurge) {
+        this.props.onPurge(this.el);
+      }
       if (this.resizeHandler && isBrowser) {
         window.removeEventListener('resize', this.handleResize);
         this.resizeHandler = null;
@@ -269,6 +272,7 @@ export default function plotComponentFactory(Plotly) {
     frames: PropTypes.arrayOf(PropTypes.object),
     revision: PropTypes.number,
     onInitialized: PropTypes.func,
+    onPurge: PropTypes.func,
     onError: PropTypes.func,
     onUpdate: PropTypes.func,
     debug: PropTypes.bool,

--- a/src/react-plotly.js
+++ b/src/react-plotly.js
@@ -1,5 +1,5 @@
-import plotComponentFactory from "./factory";
-import Plotly from "plotly.js";
+import plotComponentFactory from './factory';
+import Plotly from 'plotly.js';
 
 const PlotComponent = plotComponentFactory(Plotly);
 


### PR DESCRIPTION
This adds an onPurge callback to the component. Currently this component calls `plotly.purge(gd)` when unmounting which strips the `graphDiv` of data, layout, _fullData and _fullLayout. This hook allows applications to take corrective action like transferring these objects to a new object.