### PR TITLE
Added id attribute for the parent<div> of the chart component

### DIFF
--- a/src/factory.js
+++ b/src/factory.js
@@ -264,6 +264,7 @@ export default function plotComponentFactory(Plotly) {
           style={this.props.style}
           ref={this.getRef}
           className={this.props.className}
+          id={this.props.chartId}
         />
       );
     }
@@ -284,6 +285,7 @@ export default function plotComponentFactory(Plotly) {
     style: PropTypes.object,
     className: PropTypes.string,
     useResizeHandler: PropTypes.bool,
+    chartId: _propTypes2.default.string
   };
 
   for (let i = 0; i < eventNames.length; i++) {


### PR DESCRIPTION
It was not possible to make interactive changes to the chart without having an id attribute for the parent <div> of the chart component. For instance, now a user can click on the parent <div> of the chart and have more flexibility in handling states of the charts.