### PR TITLE
use precompiled plotly

### DIFF
--- a/src/react-plotly.js
+++ b/src/react-plotly.js
@@ -1,5 +1,5 @@
 import plotComponentFactory from './factory';
-import Plotly from 'plotly.js';
+import Plotly from 'plotly.js/dist/plotly';
 
 const PlotComponent = plotComponentFactory(Plotly);
 


### PR DESCRIPTION
If we use a precompiled plotly here we can save users a ton of webpack headaches and make this out-of-the-box compatible with create-react-app.