### PR TITLE
Update preset from 'es2015' (deprecated) to 'env'

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,3 @@
 {
-  "presets": ["react", "es2015"],
+  "presets": ["react", "env"],
 }


### PR DESCRIPTION
Fixes issue #70

Will require users to update packages by installing `babel-preset-env`