### PR TITLE
Use plotly-dist as peer dep to fix import issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@
 ## Installation
 
 ```bash
-$ npm install react-plotly.js plotly.js
+$ npm install react-plotly.js plotly.js-dist
 ```
 
 ## Quick start

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "uglify-js": "^3.0.26"
   },
   "peerDependencies": {
-    "plotly.js": ">1.34.0",
+    "plotly.js-dist": ">1.34.0",
     "react": ">12.0.0"
   },
   "browserify-global-shim": {

--- a/src/react-plotly.js
+++ b/src/react-plotly.js
@@ -1,5 +1,5 @@
 import plotComponentFactory from './factory';
-import Plotly from 'plotly.js/dist/plotly';
+import Plotly from 'plotly.js-dist/plotly';
 
 const PlotComponent = plotComponentFactory(Plotly);
 


### PR DESCRIPTION
This would fix #93 although I'm slightly worried if this would require a (possibly unwanted) new major version.