### PR TITLE
Fix conditions for plot being refreshed

### DIFF
--- a/src/factory.js
+++ b/src/factory.js
@@ -84,30 +84,34 @@ export default function plotComponentFactory(Plotly) {
     }
 
     componentWillUpdate(nextProps) {
-      if (
-        nextProps.revision !== void 0 &&
-        nextProps.revision === this.props.revision
-      ) {
-        // if revision is set and unchanged, do nothing
-        return;
+      var doNothing = false;
+
+      // If revision is set and unchanged, do nothing.
+      if ((nextProps.revision !== void 0)
+         && (nextProps.revision === this.props.revision)) {
+      	doNothing = true;
       }
 
-      const numPrevFrames =
-        this.props.frames && this.props.frames.length
-          ? this.props.frames.length
-          : 0;
-      const numNextFrames =
-        nextProps.frames && nextProps.frames.length
-          ? nextProps.frames.length
-          : 0;
-      if (
-        nextProps.layout === this.props.layout &&
-        nextProps.data === this.props.data &&
-        nextProps.config === this.props.config &&
-        numNextFrames === numPrevFrames
-      ) {
-        // prevent infinite loops when component is re-rendered after onUpdate
-        // frames *always* changes identity so fall back to check length only :(
+      const numPrevFrames = (this.props.frames && this.props.frames.length)
+                            ? this.props.frames.length
+                            : 0;
+      const numNextFrames = (nextProps.frames && nextProps.frames.length)
+                            ? nextProps.frames.length
+                            : 0;
+
+      /* If none of data, layout, or config have changed identity and the
+      number of elements in frames has not changed, do nothing. This
+      prevents infinite loops when the component is re-rendered after
+      onUpdate. frames *always* changes identity, so check its length
+      insead. */
+      if ((nextProps.layout === this.props.layout)
+         && (nextProps.data === this.props.data)
+         && (nextProps.config === this.props.config)
+         && (numNextFrames === numPrevFrames)) {
+        doNothing = true;
+      }
+
+      if (doNothing) {
         return;
       }
 


### PR DESCRIPTION
Previously, changing the revision prop alone was not sufficient to cause
the plot to be refreshed, contrary to the behavior indicated in the
REAMDE. Fix this so that the revision prop can be used to force the
plot to be refreshed.

Resolves: #59