### PR TITLE
Package upgrades; babel 6 -> 7

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,3 @@
 {
-  "presets": ["react", "env"]
+  "presets": ["@babel/react", "@babel/env"]
 }

--- a/.eslintrc
+++ b/.eslintrc
@@ -1,8 +1,15 @@
 {
   "extends": [
     "eslint:recommended",
+    "plugin:react/recommended",
     "prettier"
   ],
+  "settings": {
+    "react": {
+      "pragma": "React",
+      "version": "detect"
+    }
+  },
   "parser": "babel-eslint",
   "parserOptions": {
     "ecmaVersion": 6,
@@ -33,16 +40,6 @@
   "plugins": [
     "react",
     "import"
-  ],
-  "overrides": [
-    {
-      "files": [
-        "**/*.percy.{js,jsx}"
-      ],
-      "env": {
-        "react-percy/globals": true
-      }
-    }
   ],
   "rules": {
     "accessor-pairs": [

--- a/package.json
+++ b/package.json
@@ -13,8 +13,8 @@
     "url": "https://github.com/plotly/react-plotly.js/issues"
   },
   "scripts": {
-    "make:lib": "mkdirp lib && babel src --out-dir=lib --ignore __tests__/*.js,__mocks__/*.js --presets=env,react --source-maps --plugins babel-plugin-add-module-exports && mv lib/* ./ && rmdir lib",
-    "make:dist": "mkdirp dist && browserify src/factory.js -o ./dist/create-plotly-component.js -t [ babelify --presets [ env react ] --plugins add-module-exports ] -t browserify-global-shim --standalone createPlotlyComponent && uglifyjs ./dist/create-plotly-component.js --compress --mangle --output ./dist/create-plotly-component.min.js --source-map filename=dist/create-plotly-component.min.js.map",
+    "make:lib": "mkdirp lib && babel src --out-dir lib --ignore \"src/__tests__/*.js\",\"src/__mocks__/*.js\" --presets=@babel/preset-env,@babel/preset-react --source-maps && mv lib/* ./ && rmdir lib",
+    "make:dist": "mkdirp dist && browserify src/factory.js -o ./dist/create-plotly-component.js -t [ babelify --presets [ @babel/preset-env @babel/preset-react ] --plugins [ @babel/plugin-proposal-class-properties ] ] -t browserify-global-shim --standalone createPlotlyComponent && uglifyjs ./dist/create-plotly-component.js --compress --mangle --output ./dist/create-plotly-component.min.js --source-map filename=dist/create-plotly-component.min.js.map",
     "clean": "rimraf lib dist react-plotly.js react-plotly.js.map factory.js factory.js.map",
     "prepublishOnly": "npm run clean && npm run make:lib && npm run make:dist",
     "lint": "prettier --trailing-comma es5 --write \"src/**/*.js\" && eslint src",
@@ -32,34 +32,35 @@
     "react"
   ],
   "devDependencies": {
-    "babel-cli": "^6.24.1",
+    "@babel/cli": "^7.2.3",
+    "@babel/core": "^7.3.3",
+    "@babel/plugin-proposal-class-properties": "^7.3.3",
+    "@babel/preset-env": "^7.3.1",
+    "@babel/preset-react": "^7.0.0",
     "babel-eslint": "^10.0.1",
-    "babel-plugin-add-module-exports": "^0.2.1",
-    "babel-plugin-transform-class-properties": "^6.24.1",
-    "babel-preset-env": "^1.7.0",
-    "babel-preset-react": "^6.24.1",
-    "babelify": "^7.3.0",
-    "brfs": "^1.4.3",
-    "browserify": "^14.4.0",
+    "babelify": "^10.0.0",
+    "brfs": "^2.0.2",
+    "browserify": "^16.2.3",
     "browserify-global-shim": "^1.0.3",
     "cash-mv": "^0.2.0",
-    "dependency-check": "^2.9.1",
-    "enzyme": "^2.9.1",
-    "eslint": "^4.8.0",
+    "dependency-check": "^3.3.0",
+    "enzyme": "^3.9.0",
+    "enzyme-adapter-react-16": "^1.9.1",
+    "eslint": "^5.14.1",
     "eslint-config-prettier": "^4.0.0",
     "eslint-plugin-import": "^2.16.0",
-    "eslint-plugin-react": "^7.4.0",
+    "eslint-plugin-react": "^7.12.4",
     "event-emitter": "^0.3.5",
-    "jest": "^20.0.4",
+    "jest": "^24.1.0",
     "mkdirp": "^0.5.1",
-    "nodemon": "^1.11.0",
-    "onetime": "^1.1.0",
+    "nodemon": "^1.18.10",
+    "onetime": "^3.0.0",
     "plotly.js": "^1.35.0",
-    "prettier": "^1.5.3",
-    "react": "^15.6.1",
+    "prettier": "^1.16.4",
+    "react": "^16.8.2",
     "react-addons-test-utils": "^15.6.0",
-    "react-dom": "^15.6.1",
-    "react-test-renderer": "^15.6.1",
+    "react-dom": "^16.8.2",
+    "react-test-renderer": "^16.8.2",
     "rimraf": "^2.6.2",
     "semver": "^5.4.1",
     "uglify-js": "^3.0.26"
@@ -72,6 +73,6 @@
     "react": "React"
   },
   "dependencies": {
-    "prop-types": "^15.5.10"
+    "prop-types": "^15.7.2"
   }
 }

--- a/src/__tests__/react-plotly.test.js
+++ b/src/__tests__/react-plotly.test.js
@@ -1,10 +1,12 @@
 import React from 'react';
-import {mount} from 'enzyme';
+import Adapter from 'enzyme-adapter-react-16';
+import {mount, configure} from 'enzyme';
 import createComponent from '../factory';
 import once from 'onetime';
 
 describe('<Plotly/>', () => {
   let Plotly, PlotComponent;
+  configure({adapter: new Adapter()});
 
   function createPlot(props) {
     return new Promise((resolve, reject) => {

--- a/src/factory.js
+++ b/src/factory.js
@@ -100,7 +100,7 @@ export default function plotComponentFactory(Plotly) {
         });
     }
 
-    componentWillUpdate(nextProps) {
+    UNSAFE_componentWillUpdate(nextProps) {
       this.unmounting = false;
 
       if (nextProps.revision !== void 0 && nextProps.revision === this.props.revision) {


### PR DESCRIPTION
Update all packages, including babel 6->7

Minified/uglified file output in /dist dir went from 23,284 bytes to 23,856 bytes. I guess nobody promised us a smaller file from using Babel 7 😐 