### PR TITLE
Allow events to be replaced

### DIFF
--- a/src/__tests__/react-plotly.test.js
+++ b/src/__tests__/react-plotly.test.js
@@ -164,5 +164,20 @@ describe('<Plotly/>', () => {
           .catch(err => done.fail(err));
       });
     });
+
+    describe('manging event handlers', () => {
+      test('should add an event handler when one does not already exist', (done) => {
+        const onRelayout = () => {};
+
+        createPlot({onRelayout}).then((plot) => {
+          const { handlers } = plot.instance();
+
+          expect(plot.prop('onRelayout')).toBe(onRelayout);
+          expect(handlers.Relayout).toBe(onRelayout);
+
+          done();
+        });
+      });
+    });
   });
 });

--- a/src/factory.js
+++ b/src/factory.js
@@ -214,10 +214,10 @@ export default function plotComponentFactory(Plotly) {
           this.addEventHandler(eventName, prop);
         } else if (!prop && hasHandler) {
           // Needs to be removed:
-          this.removeHandler(eventName);
+          this.removeEventHandler(eventName);
         } else if (prop && hasHandler && prop !== handler) {
           // replace the handler
-          this.removeHandler(eventName);
+          this.removeEventHandler(eventName);
           this.addEventHandler(eventName, prop);
         }
       });

--- a/src/factory.js
+++ b/src/factory.js
@@ -207,17 +207,34 @@ export default function plotComponentFactory(Plotly) {
     syncEventHandlers() {
       eventNames.forEach(eventName => {
         const prop = this.props['on' + eventName];
-        const hasHandler = Boolean(this.handlers[eventName]);
+        const handler = this.handlers[eventName];
+        const hasHandler = Boolean(handler);
 
         if (prop && !hasHandler) {
-          this.handlers[eventName] = prop;
-          this.el.on('plotly_' + eventName.toLowerCase(), this.handlers[eventName]);
+          this.addEventHandler(eventName, prop);
         } else if (!prop && hasHandler) {
           // Needs to be removed:
-          this.el.removeListener('plotly_' + eventName.toLowerCase(), this.handlers[eventName]);
-          delete this.handlers[eventName];
+          this.removeHandler(eventName);
+        } else if (prop && hasHandler && prop !== handler) {
+          // replace the handler
+          this.removeHandler(eventName);
+          this.addEventHandler(eventName, prop);
         }
       });
+    }
+
+    addEventHandler(eventName, prop) {
+      this.handlers[eventName] = prop;
+      this.el.on(this.getPlotlyEventName(eventName), this.handlers[eventName]);
+    }
+
+    removeEventHandler(eventName) {
+      this.el.removeListener(this.getPlotlyEventName(eventName), this.handlers[eventName]);
+      delete this.handlers[eventName];
+    }
+
+    getPlotlyEventName(eventName) {
+      return 'plotly_' + eventName.toLowerCase();
     }
 
     render() {


### PR DESCRIPTION
Addresses #150 

- Moved code for adding an event to `addEventHandler`
- Moved code for removing an event to `removeEventHandler`
- Created utility function for formatting plotly event names
- Added 3rd condition to `syncEventHandlers` that will replace a handler if it is not the already-stored handler