### PR TITLE
Update event handlers if they changed

### DIFF
--- a/src/factory.js
+++ b/src/factory.js
@@ -207,15 +207,23 @@ export default function plotComponentFactory(Plotly) {
     syncEventHandlers() {
       eventNames.forEach(eventName => {
         const prop = this.props['on' + eventName];
-        const hasHandler = Boolean(this.handlers[eventName]);
+        const prevHandler = this.handlers[eventName];
+        const hasHandler = Boolean(prevHandler);
 
-        if (prop && !hasHandler) {
+        const registerListener = () => {
           this.handlers[eventName] = prop;
           this.el.on('plotly_' + eventName.toLowerCase(), this.handlers[eventName]);
+        }
+
+        if (prop && !hasHandler) {
+          registerListener();
         } else if (!prop && hasHandler) {
           // Needs to be removed:
           this.el.removeListener('plotly_' + eventName.toLowerCase(), this.handlers[eventName]);
           delete this.handlers[eventName];
+        } else if (prop && hasHandler && prop !== prevHandler) {
+          this.el.removeListener('plotly_' + eventName.toLowerCase(), this.handlers[eventName]);
+          registerListener();
         }
       });
     }


### PR DESCRIPTION
The original code doesn't handle the case when the event handler changes on an update.

My use case:

- I have a chart on my page. A click on a bar selects the corresponding category, so the chart is updated, the selected bar becomes more prominent while the other bars become almost transparent.
- In this state, a click deselects the previously selected category, removing all the highlight effects.

Currently this is impossible since the click handler is not updated when a new one is provided in the `props` on update.

I haven't found any contribution guide, so let me know if there are some steps I should take before this can be merged.