### PR TITLE
Added support for the onRelayouting event.

### DIFF
--- a/src/factory.js
+++ b/src/factory.js
@@ -22,6 +22,7 @@ const eventNames = [
   'LegendClick',
   'LegendDoubleClick',
   'Relayout',
+  'Relayouting',
   'Restyle',
   'Redraw',
   'Selected',
@@ -38,6 +39,7 @@ const updateEvents = [
   'plotly_restyle',
   'plotly_redraw',
   'plotly_relayout',
+  'plotly_relayouting',
   'plotly_doubleclick',
   'plotly_animated',
 ];


### PR DESCRIPTION
I noticed that the `onRelayouting` event was missing.

Adding it seemed almost too easy... Just with these two lines I was able to get it working on my application. Can you maybe check that this is correct? Especially my assumption about needing to add the event name in the `updateEvents` array.

I did not see any event-specific tests in the regression tests files so I didn't add any.