### PR TITLE
Add support for onSunburstClick/plotly_sunburstclick event

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,7 @@ Event handlers for specific [`plotly.js` events](https://plot.ly/javascript/plot
 | `onSliderChange`          | `Function` | `plotly_sliderchange`          |
 | `onSliderEnd`             | `Function` | `plotly_sliderend`             |
 | `onSliderStart`           | `Function` | `plotly_sliderstart`           |
+| `onSunburstClick`         | `Function` | `plotly_sunburstclick`         |
 | `onTransitioning`         | `Function` | `plotly_transitioning`         |
 | `onTransitionInterrupted` | `Function` | `plotly_transitioninterrupted` |
 | `onUnhover`               | `Function` | `plotly_unhover`               |

--- a/src/factory.js
+++ b/src/factory.js
@@ -30,6 +30,7 @@ const eventNames = [
   'SliderChange',
   'SliderEnd',
   'SliderStart',
+  'SunburstClick',
   'Transitioning',
   'TransitionInterrupted',
   'Unhover',


### PR DESCRIPTION
Tried this locally and it seems to work.

The default behaviour of sunburst click is to zoom in/out on a sub-section of a sunburst plot.

I'm not sure what the `updateEvents` array does, or whether this needs to be added there too.