### PR TITLE
depend on plotly.js-dist instead of plotly.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "mkdirp": "^1.0.4",
     "nodemon": "^2.0.4",
     "onetime": "^5.1.2",
-    "plotly.js": "^1.35.0",
+    "plotly.js-dist": "^1.39.0",
     "prettier": "^2.1.1",
     "react": "^16.13.1",
     "react-addons-test-utils": "^15.6.0",
@@ -69,7 +69,7 @@
     "uglify-js": "^3.10.4"
   },
   "peerDependencies": {
-    "plotly.js": ">1.34.0",
+    "plotly.js-dist": ">=1.39.0",
     "react": ">0.13.0"
   },
   "browserify-global-shim": {

--- a/src/react-plotly.js
+++ b/src/react-plotly.js
@@ -1,5 +1,5 @@
 import plotComponentFactory from './factory';
-import Plotly from 'plotly.js/dist/plotly';
+import Plotly from 'plotly.js-dist';
 
 const PlotComponent = plotComponentFactory(Plotly);
 


### PR DESCRIPTION
Wondering if this is the right fix in respect to https://github.com/plotly/plotly.js/issues/5182#issuecomment-702055766?

@dmt0 @nicolaskruchten 