### PR TITLE
add plotly_beforehover event

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ Event handlers for specific [`plotly.js` events](https://plot.ly/javascript/plot
 | `onAnimationInterrupted`  | `Function` | `plotly_animationinterrupted`  |
 | `onAutoSize`              | `Function` | `plotly_autosize`              |
 | `onBeforeExport`          | `Function` | `plotly_beforeexport`          |
+| `onBeforeHover`           | `Function` | `plotly_beforehover`           |
 | `onButtonClicked`         | `Function` | `plotly_buttonclicked`         |
 | `onClick`                 | `Function` | `plotly_click`                 |
 | `onClickAnnotation`       | `Function` | `plotly_clickannotation`       |

--- a/src/factory.js
+++ b/src/factory.js
@@ -12,6 +12,7 @@ const eventNames = [
   'AnimationInterrupted',
   'AutoSize',
   'BeforeExport',
+  'BeforeHover',
   'ButtonClicked',
   'Click',
   'ClickAnnotation',


### PR DESCRIPTION
plotly_beforehover used to disable default hover logic. 
Here is example:
https://plotly.com/javascript/hover-events/#triggering-hover-events
