### PR TITLE
Add onWebGlContextLost event

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,7 @@ Event handlers for specific [`plotly.js` events](https://plot.ly/javascript/plot
 | `onTransitioning`         | `Function` | `plotly_transitioning`         |
 | `onTransitionInterrupted` | `Function` | `plotly_transitioninterrupted` |
 | `onUnhover`               | `Function` | `plotly_unhover`               |
+| `onWebGlContextLost`      | `Function` | `plotly_webglcontextlost`      |
 
 ## Customizing the `plotly.js` bundle
 

--- a/src/factory.js
+++ b/src/factory.js
@@ -35,6 +35,7 @@ const eventNames = [
   'Transitioning',
   'TransitionInterrupted',
   'Unhover',
+  'WebGlContextLost',
 ];
 
 const updateEvents = [


### PR DESCRIPTION
Added support for the [plotly_webglcontextlost](https://plotly.com/javascript/plotlyjs-events/#webgl-context-lost-event) event: resolves #220. 