### PR TITLE
Warning if using frozen props

### DIFF
--- a/src/factory.js
+++ b/src/factory.js
@@ -107,6 +107,10 @@ export default function plotComponentFactory(Plotly) {
 
     componentDidMount() {
       this.unmounting = false;
+      
+      if (Object.isFrozen(this.props.data)) {
+        console.warn("react-plotly.js expects mutable data and layout props");
+      }
 
       this.updatePlotly(true, this.props.onInitialized, true);
     }


### PR DESCRIPTION
Adds a warning if the passed in data prop is `Object.freeze`'d.

This is important since several React state managers return values that are frozen (in my case, Apollo). Currently, this just causes the plot to completely fail to render and gives no indication as to what's wrong.