### PR TITLE
Avoids purging el on unmount if el is not found

### DIFF
--- a/src/factory.js
+++ b/src/factory.js
@@ -148,6 +148,10 @@ export default function plotComponentFactory(Plotly) {
 
       this.removeUpdateEvents();
 
+      if (!this.el) {
+        return;
+      }
+      
       Plotly.purge(this.el);
     }
 


### PR DESCRIPTION
Fixes an issue where unmount will be called after the page changes and this.el can no longer be found. In my case, this happened using react-plotly in a creat-react-app app + react-router app when the route changed away from a page using plotly.