### PR TITLE
Add plotly_treemapclick to event handler props

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,7 @@ Event handlers for specific [`plotly.js` events](https://plot.ly/javascript/plot
 | `onSunburstClick`         | `Function` | `plotly_sunburstclick`         |
 | `onTransitioning`         | `Function` | `plotly_transitioning`         |
 | `onTransitionInterrupted` | `Function` | `plotly_transitioninterrupted` |
+| `onTreemapClick`          | `Function` | `plotly_treemapclick`          |
 | `onUnhover`               | `Function` | `plotly_unhover`               |
 | `onWebGlContextLost`      | `Function` | `plotly_webglcontextlost`      |
 

--- a/src/factory.js
+++ b/src/factory.js
@@ -34,6 +34,7 @@ const eventNames = [
   'SunburstClick',
   'Transitioning',
   'TransitionInterrupted',
+  'TreemapClick',
   'Unhover',
   'WebGlContextLost',
 ];
@@ -46,6 +47,7 @@ const updateEvents = [
   'plotly_doubleclick',
   'plotly_animated',
   'plotly_sunburstclick',
+  'plotly_treemapclick',
 ];
 
 // Check if a window is available since SSR (server-side rendering)


### PR DESCRIPTION
This adds an `onTreemapClick` prop to handle `plotly_treemapclick` events.