### PR TITLE
fix: Update type to reflect forwardRef wrapped component

### DIFF
--- a/src/factory.d.ts
+++ b/src/factory.d.ts
@@ -71,7 +71,15 @@ export interface PlotParams {
  * Build a Plot component bound to a specific plotly.js instance. Use this
  * when shipping a custom plotly.js bundle (e.g. the basic, cartesian, or
  * a custom partial bundle) instead of the full library.
+ *
+ * The returned component is `forwardRef`-wrapped, so consumers can attach a
+ * ref to access the underlying graph div (e.g. for `Plotly.animate` calls
+ * outside the React update cycle).
  */
-declare function createPlotlyComponent(Plotly: unknown): React.ComponentType<PlotParams>;
+declare function createPlotlyComponent(
+  Plotly: unknown
+): React.ForwardRefExoticComponent<
+  PlotParams & React.RefAttributes<HTMLDivElement>
+>;
 
 export default createPlotlyComponent;

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,7 +1,9 @@
 import type React from 'react';
 import type {PlotParams} from './factory';
 
-declare const Plot: React.ComponentType<PlotParams>;
+declare const Plot: React.ForwardRefExoticComponent<
+  PlotParams & React.RefAttributes<HTMLDivElement>
+>;
 
 export default Plot;
 export {Figure, FigureCallback, EventCallback, PlotParams} from './factory';


### PR DESCRIPTION
### Description

Update the type declaration to reflect that the `Plot` component is `forwardRef` wrapped.